### PR TITLE
feat: [VERA-6] dark theme sync and footer font loading

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,3 @@ jobs:
       run: npm run build
     - name: i18n_extract
       run: npm run i18n_extract
-    - name: Coverage
-      uses: codecov/codecov-action@v4
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        fail_ci_if_error: true

--- a/RG_CHANGELOG.rst
+++ b/RG_CHANGELOG.rst
@@ -21,3 +21,7 @@ Changed:
 Fixed:
 ======
 * Center the header theme-toggle icon within its button (ENG-63)
+
+Removed:
+========
+* codecov CI action — the fork has no codecov project, so the step failed every run (VERA-6)

--- a/RG_CHANGELOG.rst
+++ b/RG_CHANGELOG.rst
@@ -1,0 +1,14 @@
+RG Changelog
+############
+
+All notable changes to this project will be documented in this file.
+
+The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_,
+and this project adheres to customized Semantic Versioning e.g.: `verawood-rg.1`
+
+[Unreleased]
+************
+
+Changed:
+========
+* changed FooterSlot loading method to ensure basic ``subscribe`` works (TEA-289)

--- a/RG_CHANGELOG.rst
+++ b/RG_CHANGELOG.rst
@@ -9,6 +9,15 @@ and this project adheres to customized Semantic Versioning e.g.: `verawood-rg.1`
 [Unreleased]
 ************
 
+Added:
+======
+* Adopt the shared ``theme-variant`` cookie as the active theme in all modes, including the in-context sidebar iframe (ENG-63)
+* Apply a dark content style to the TinyMCE editor surface when dark theme is active (ENG-63)
+
 Changed:
 ========
 * changed FooterSlot loading method to ensure basic ``subscribe`` works (TEA-289)
+
+Fixed:
+======
+* Center the header theme-toggle icon within its button (ENG-63)

--- a/src/components/TinyMCEEditor.jsx
+++ b/src/components/TinyMCEEditor.jsx
@@ -93,9 +93,31 @@ const TinyMCEEditor = (props) => {
   }, []);
 
   let contentStyle;
+  // The editor's writing-surface <iframe> loads ONLY this `content_style` (not the
+  // page's dark Paragon variant), so in dark mode its default black text renders
+  // unreadably on the dark body. When the shared `theme-variant=dark` cookie is set,
+  // append a dark content style (mirrors authoring's TinyMceWidget darkContentStyle
+  // and the legacy ORA editor head-extra injection): dark body + light text + the
+  // readable brand-green link shade used elsewhere for dark content surfaces.
+  const isDarkTheme = typeof document !== 'undefined'
+    && /(?:^|;)\s*theme-variant=dark(?:;|$)/.test(document.cookie || '');
+  const darkContentStyle = `
+    body, body.mce-content-body, body.text-editor {
+      background-color: #212529 !important;
+      color: #e8e8e8 !important;
+    }
+    body a { color: #6ccb6c !important; }
+    body blockquote {
+      border-left-color: #5c5c5c !important;
+      color: #e8e8e8 !important;
+    }
+    body code { background-color: rgba(255, 255, 255, 0.08) !important; color: #f48fb1 !important; }
+    body th, body td { border-color: #5c5c5c !important; }
+    body hr { border-color: #5c5c5c !important; }
+  `;
   // In the test environment this causes an error so set styles to empty since they aren't needed for testing.
   try {
-    contentStyle = [contentCss, contentUiCss, edxBrandCss].join('\n');
+    contentStyle = [contentCss, contentUiCss, edxBrandCss, isDarkTheme ? darkContentStyle : ''].join('\n');
   } catch (err) {
     contentStyle = '';
   }

--- a/src/discussions/discussions-home/DiscussionsHome.jsx
+++ b/src/discussions/discussions-home/DiscussionsHome.jsx
@@ -8,6 +8,8 @@ import {
   matchPath, Route, Routes, useLocation, useMatch,
 } from 'react-router-dom';
 
+import { FooterSlot } from '@edx/frontend-component-footer';
+
 import { Spinner } from '../../components';
 import selectCourseTabs from '../../components/NavigationBar/data/selectors';
 import { ALL_ROUTES, DiscussionProvider, Routes as ROUTES } from '../../data/constants';
@@ -26,7 +28,6 @@ import { selectPostEditorVisible } from '../posts/data/selectors';
 import { isCourseStatusValid } from '../utils';
 import useFeedbackWrapper from './FeedbackWrapper';
 
-const FooterSlot = lazy(() => import('@edx/frontend-component-footer').then(module => ({ default: module.FooterSlot })));
 const PostActionsBar = lazy(() => import('../posts/post-actions-bar/PostActionsBar'));
 const CourseTabsNavigation = lazy(() => import('../../components/NavigationBar/CourseTabsNavigation'));
 const LegacyBreadcrumbMenu = lazy(() => import('../navigation/breadcrumb-menu/LegacyBreadcrumbMenu'));

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -6,6 +6,7 @@ import React, { StrictMode } from 'react';
 // eslint-disable-next-line import/no-unresolved
 import { createRoot } from 'react-dom/client';
 
+import { HeaderThemeSync } from '@edx/frontend-component-header';
 import {
   APP_INIT_ERROR, APP_READY, initialize, mergeConfig,
   subscribe,
@@ -24,6 +25,9 @@ subscribe(APP_READY, () => {
   rootNode.render(
     <StrictMode>
       <AppProvider store={store}>
+        {/* Headless theme-variant sync, reused from the shared (overridden) header.
+            Guard so a header build without this export can't crash the app. */}
+        {HeaderThemeSync && <HeaderThemeSync />}
         <Head />
         <DiscussionsHome />
       </AppProvider>

--- a/src/index.scss
+++ b/src/index.scss
@@ -392,6 +392,28 @@ header {
   color: var(--pgn-color-primary-500) !important
 }
 
+// The header theme toggle's icon sat ~2px below the button's vertical centre:
+// the `header span:first-child { margin-top:1px; margin-bottom:-1px }` rule above
+// also matches the IconButton's `.btn-icon__icon-container` span (a first-child
+// span in the header), shoving the icon down. Reset those margins and flex-centre
+// the icon so it is perfectly centred within the round button.
+.theme-toggle {
+  align-items: center;
+
+  .btn-icon__icon-container,
+  .pgn__icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-top: 0 !important;
+    margin-bottom: 0 !important;
+  }
+
+  svg {
+    display: block;
+  }
+}
+
 
 @media only screen and (max-width: 767px) {
   body:not(.tox-force-desktop) .tox .tox-dialog {


### PR DESCRIPTION
## Description

The Discussions app renders its own page chrome, which left it outside two things
the rest of the site gets for free: the brand fonts, and the reader's light/dark
choice. Fonts never loaded at all, because the component that registers font
loading was code-split and evaluated after the app had already signalled it was
ready. Separately, the rich-text editor's writing area is its own embedded frame,
so in dark mode it kept black text on a dark background — effectively unusable.

This change makes Discussions follow the shared theme in every mode, including the
in-context sidebar embedded inside the courseware, gives the editor a readable dark
writing surface, and restores brand font loading. It also re-establishes the
RaccoonGang fork of this MFE on the Verawood release line, carrying only the two
fixes still needed — the Paragon v23 / design-token migration the teak-rg fork used
to hold is now shipped by upstream Verawood and is deliberately not brought over.

## Youtrack

- https://youtrack.raccoongang.com/issue/VERA-6

## Testing

1. **Brand fonts load on the discussions page**
   - Preconditions: site config supplying `CUSTOM_FONTS` and/or `GOOGLE_FONTS`; MFE built against
     the **RG** footer fork.
   - Actions: open a course's Discussions tab. In devtools, check `<head>` for the injected font
     `<style>` / Google Fonts `<link>`.
   - Expected: the font tags are present and post text renders in the brand face. Before this
     change they were absent, because the footer module was evaluated after `APP_READY`.

2. **Dark theme adopted from the shared cookie**
   - Preconditions: theme mode `both`; MFE built against the **RG** header fork.
   - Actions: switch to dark using the toggle on any page, then open Discussions.
   - Expected: the Discussions page renders dark. Reload — it stays dark.

3. **Dark theme in the in-context sidebar (no header at all)**
   - Preconditions: a course with in-context discussions enabled; dark theme active.
   - Actions: open a courseware unit and open the discussions sidebar.
   - Expected: the sidebar follows dark too. This is the case the change is really for — the
     sidebar renders no header, so it would otherwise never pick up the theme.

4. **Editor writing surface in dark mode**
   - Actions: with dark active, click "Add a post" (or reply to a thread) to open the TinyMCE
     editor. Type text, add a link, a blockquote, an inline code span and a table.
   - Expected: the writing area has a dark background with light text; the link is the readable
     green; blockquote/table/hr borders are visible; code is legible. No black-on-dark.

5. **Editor writing surface in light mode**
   - Actions: switch to light, reload, open the editor and repeat the above.
   - Expected: identical to pre-change behaviour — no dark styling applied.

6. **Theme toggle icon alignment**
   - Actions: look at the theme-toggle button in the Discussions header at desktop and mobile.
   - Expected: the glyph is centred in the round button, both vertically and horizontally.

7. **Regression: no cookie / malformed cookie**
   - Actions: clear cookies and load Discussions; then set `theme-variant=bogus` and reload.
   - Expected: falls back to light in both cases; editor gets no dark styles; no exception.

8. **Graceful degradation against the upstream header**
   - Preconditions: MFE built with upstream `@edx/frontend-component-header` 8.2.1 (no
     `HeaderThemeSync`) — the state of a plain Verawood build today.
   - Actions: open Discussions with the console open.
   - Expected: page renders, no console error, no crash — the guard skips the sync. Theme
     following is simply inactive; the editor's cookie-based dark styling still works.

9. **Regression: footer still renders and does not block first paint**
   - Actions: load Discussions normally, and again with the in-context sidebar.
   - Expected: the footer renders as before on the full page and is still absent in the
     in-context sidebar. Making the import eager must not visibly delay initial render.
